### PR TITLE
Normalize target framework entries

### DIFF
--- a/CodeChanges/UpdateDotNetVersion/UpdateNet7ToNet8.sh
+++ b/CodeChanges/UpdateDotNetVersion/UpdateNet7ToNet8.sh
@@ -1,3 +1,6 @@
 sed -i '' 's/net7/net8/g' .github/**/*.yml
 
 sed -i '' 's/net7/net8/g' ./**/*.csproj
+
+# Remove duplicate target frameworks (e.g., net8;net8 -> net8)
+sed -i '' 's/<TargetFrameworks>net8;net8<\/TargetFrameworks>/<TargetFrameworks>net8<\/TargetFrameworks>/g' ./**/*.csproj


### PR DESCRIPTION
Update `UpdateNet7ToNet8.sh` to remove duplicate target frameworks (e.g., `net8;net8`).

This prevents issues where running the script multiple times or having existing `net8` references could create duplicate target frameworks in `.csproj` files.