### PR TITLE
Fix scripts expecting .sln files in repository root after move to csharp/ directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Scripts/issues/22
-Your prepared branch: issue-22-d449aa6d
-Your prepared working directory: /tmp/gh-issue-solver-1757702865609
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Scripts/issues/22
+Your prepared branch: issue-22-d449aa6d
+Your prepared working directory: /tmp/gh-issue-solver-1757702865609
+
+Proceed.

--- a/CodeChanges/RemoveCppProjectsInSln.sh
+++ b/CodeChanges/RemoveCppProjectsInSln.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find . -type f -name "*.sln" -exec perl -0777pi -e "s~^Project.*cpp.*$\s~~gm" {} \;
+find ./csharp -type f -name "*.sln" -exec perl -0777pi -e "s~^Project.*cpp.*$\s~~gm" {} \;


### PR DESCRIPTION
## Summary

This PR completes the second part of issue #22 by updating scripts that were expecting `.sln` files to be in the repository root, after they were moved to the `csharp/` directory.

### Changes Made

- Updated `CodeChanges/RemoveCppProjectsInSln.sh` to search for `.sln` files in `./csharp` directory instead of the root directory
- Changed the find command from `find . -type f -name "*.sln"` to `find ./csharp -type f -name "*.sln"`

### Issue Context

From issue #22 checklist:
- [x] Move `sln`s to `csharp/` (already completed)
- [x] Change scripts that are expecting `sln` to be in a repository root (completed in this PR)

### Testing

- Verified the updated script correctly finds and processes `.sln` files in the `csharp/` directory
- The script maintains its original functionality while working with the new file location

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)