### PR TITLE
Add auto-loading for docfx files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Scripts/issues/6
+Your prepared branch: issue-6-4a2136d4
+Your prepared working directory: /tmp/gh-issue-solver-1757738674283
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Scripts/issues/6
-Your prepared branch: issue-6-4a2136d4
-Your prepared working directory: /tmp/gh-issue-solver-1757738674283
-
-Proceed.

--- a/MultiProjectRepository/publish-csharp-docs.sh
+++ b/MultiProjectRepository/publish-csharp-docs.sh
@@ -10,6 +10,9 @@ COMMIT_USER_NAME="linksplatform"
 COMMIT_USER_EMAIL="linksplatformtechnologies@gmail.com"
 REPOSITORY="github.com/linksplatform/$REPOSITORY_NAME"
 
+# Load DocFX configuration files
+../Utils/LoadDocfxFiles.sh .
+
 # Insert repository name into DocFX's configuration files
 sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" toc.yml
 sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" docfx.json

--- a/SingleProjectRepository/publish-docs.sh
+++ b/SingleProjectRepository/publish-docs.sh
@@ -10,6 +10,9 @@ COMMIT_USER_NAME="linksplatform"
 COMMIT_USER_EMAIL="linksplatformtechnologies@gmail.com"
 REPOSITORY="github.com/linksplatform/$REPOSITORY_NAME"
 
+# Load DocFX configuration files
+../Utils/LoadDocfxFiles.sh .
+
 # Insert repository name into DocFX's configuration files
 sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" toc.yml
 sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" docfx.json

--- a/Utils/LoadDocfxFiles.sh
+++ b/Utils/LoadDocfxFiles.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# Load docfx configuration files from the Files repository
+# Usage: ./LoadDocfxFiles.sh [target_directory]
+
+TARGET_DIR="${1:-.}"
+FILES_REPO_BASE="https://raw.githubusercontent.com/linksplatform/Files/main/docfx"
+
+echo "Loading docfx files to $TARGET_DIR..."
+
+# Create target directory if it doesn't exist
+mkdir -p "$TARGET_DIR"
+
+# Download docfx configuration files
+curl -s "$FILES_REPO_BASE/docfx.json" -o "$TARGET_DIR/docfx.json"
+curl -s "$FILES_REPO_BASE/toc.yml" -o "$TARGET_DIR/toc.yml"
+curl -s "$FILES_REPO_BASE/filter.yml" -o "$TARGET_DIR/filter.yml"
+
+echo "Docfx files loaded successfully:"
+echo "  - docfx.json"
+echo "  - toc.yml"
+echo "  - filter.yml"


### PR DESCRIPTION
## Summary
- Created `LoadDocfxFiles.sh` utility script that automatically downloads docfx configuration files from the Files repository
- Updated existing docfx scripts (`publish-docs.sh` and `publish-csharp-docs.sh`) to use the auto-loading functionality
- Resolves issue #6 by implementing automatic loading from https://github.com/linksplatform/Files/tree/main/docfx

## Changes Made
- **New file**: `Utils/LoadDocfxFiles.sh` - Script to download `docfx.json`, `toc.yml`, and `filter.yml` from Files repository
- **Modified**: `SingleProjectRepository/publish-docs.sh` - Added auto-loading call before processing
- **Modified**: `MultiProjectRepository/publish-csharp-docs.sh` - Added auto-loading call before processing

## Test plan
- [x] Script successfully downloads all three required files (`docfx.json`, `toc.yml`, `filter.yml`)
- [x] Downloaded files have correct content matching the source repository
- [x] Existing docfx scripts properly integrate with the new auto-loading functionality
- [x] Script handles target directory parameter correctly

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #6