### PR TITLE
Fix AddNet5Support script to not update C# to C++ translator paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Scripts/issues/5
-Your prepared branch: issue-5-5295a3a5
-Your prepared working directory: /tmp/gh-issue-solver-1757749210871
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Scripts/issues/5
+Your prepared branch: issue-5-5295a3a5
+Your prepared working directory: /tmp/gh-issue-solver-1757749210871
+
+Proceed.

--- a/CodeChanges/AddNet5Support.sh
+++ b/CodeChanges/AddNet5Support.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Use netcoreapp3.1 instead of netcoreapp3.0 (can be used separately)
-find . -type f -name "*.csproj" -print0 | xargs -0 sed -i -e 's/netcoreapp3\.0/netcoreapp3.1/g'
+find . -type f -name "*.csproj" -print0 | xargs -0 sed -i -e 's/<TargetFramework>netcoreapp3\.0<\/TargetFramework>/<TargetFramework>netcoreapp3.1<\/TargetFramework>/g' -e 's/netcoreapp3\.0\([;<]\)/netcoreapp3.1\1/g' -e 's/netcoreapp3\.0<\/TargetFrameworks/netcoreapp3.1<\/TargetFrameworks/g'
 
 # Use net5 instead of netcoreapp3.1 in automated tests
 find . -type f -name "*.yml" -print0 | xargs -0 sed -i -e 's/dotnet test -c Release -f netcoreapp3.1/dotnet test -c Release -f net5/g'

--- a/examples/experiments/full_test.csproj
+++ b/examples/experiments/full_test.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0;netstandard2.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <Target Name="CSharpToCppTranslation" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' AND $(TargetFramework) == 'netcoreapp3.0'">
+    <Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.0\CSharpToCppTranslator.exe $(ProjectDir) $(SolutionDir)cpp\$(ProjectName)\ .cs .cpp"></Exec>
+  </Target>
+
+</Project>

--- a/examples/experiments/full_test_result.csproj
+++ b/examples/experiments/full_test_result.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0;netstandard2.1;net5</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <Target Name="CSharpToCppTranslation" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' AND $(TargetFramework) == 'netcoreapp3.0'">
+    <Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.0\CSharpToCppTranslator.exe $(ProjectDir) $(SolutionDir)cpp\$(ProjectName)\ .cs .cpp"></Exec>
+  </Target>
+
+</Project>

--- a/examples/experiments/improved_test_result.csproj
+++ b/examples/experiments/improved_test_result.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;netstandard2.1;net5</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <Target Name="CSharpToCppTranslation" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' AND $(TargetFramework) == 'netcoreapp3.0'">
+    <Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.0\CSharpToCppTranslator.exe $(ProjectDir) $(SolutionDir)cpp\$(ProjectName)\ .cs .cpp"></Exec>
+  </Target>
+
+</Project>

--- a/examples/experiments/test.csproj
+++ b/examples/experiments/test.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <Target Name="CSharpToCppTranslation" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' AND $(TargetFramework) == 'netcoreapp3.0'">
+    <Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.0\CSharpToCppTranslator.exe $(ProjectDir) $(SolutionDir)cpp\$(ProjectName)\ .cs .cpp"></Exec>
+  </Target>
+
+</Project>

--- a/examples/experiments/test_full_script.sh
+++ b/examples/experiments/test_full_script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Test the complete fixed script
+
+cp full_test.csproj full_test_result.csproj
+echo "=== Testing complete fixed script ==="
+echo "Before:"
+cat full_test_result.csproj
+
+# Apply all the fixed script commands
+# Step 1: Use netcoreapp3.1 instead of netcoreapp3.0
+sed -i -e 's/<TargetFramework>netcoreapp3\.0<\/TargetFramework>/<TargetFramework>netcoreapp3.1<\/TargetFramework>/g' -e 's/netcoreapp3\.0<\/TargetFrameworks/netcoreapp3.1<\/TargetFrameworks/g' full_test_result.csproj
+
+# Step 2: Add net5 target framework 
+sed -i -e 's|netstandard2\.1<\/TargetFrameworks|netstandard2.1;net5<\/TargetFrameworks|g' -e 's|netcoreapp3\.1<\/TargetFrameworks|netcoreapp3.1;net5<\/TargetFrameworks|g' full_test_result.csproj
+
+# Step 3: Replace application's target framework
+sed -i -e 's|<TargetFramework>netcoreapp3\.1<\/TargetFramework>|<TargetFramework>net5<\/TargetFramework>|g' full_test_result.csproj
+
+echo ""
+echo "After (should preserve CSharpToCppTranslator path):"
+cat full_test_result.csproj

--- a/examples/experiments/test_improved_script.sh
+++ b/examples/experiments/test_improved_script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Test the improved fixed script
+
+cp full_test.csproj improved_test_result.csproj
+echo "=== Testing improved fixed script ==="
+echo "Before:"
+cat improved_test_result.csproj
+
+# Apply the improved script commands
+# Step 1: Use netcoreapp3.1 instead of netcoreapp3.0 (improved version)
+sed -i -e 's/<TargetFramework>netcoreapp3\.0<\/TargetFramework>/<TargetFramework>netcoreapp3.1<\/TargetFramework>/g' -e 's/netcoreapp3\.0\([;<]\)/netcoreapp3.1\1/g' -e 's/netcoreapp3\.0<\/TargetFrameworks/netcoreapp3.1<\/TargetFrameworks/g' improved_test_result.csproj
+
+# Step 2: Add net5 target framework 
+sed -i -e 's|netstandard2\.1<\/TargetFrameworks|netstandard2.1;net5<\/TargetFrameworks|g' -e 's|netcoreapp3\.1<\/TargetFrameworks|netcoreapp3.1;net5<\/TargetFrameworks|g' improved_test_result.csproj
+
+# Step 3: Replace application's target framework
+sed -i -e 's|<TargetFramework>netcoreapp3\.1<\/TargetFramework>|<TargetFramework>net5<\/TargetFramework>|g' improved_test_result.csproj
+
+echo ""
+echo "After (should properly transform TargetFrameworks and preserve CSharpToCppTranslator path):"
+cat improved_test_result.csproj

--- a/examples/experiments/test_new_result.csproj
+++ b/examples/experiments/test_new_result.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <Target Name="CSharpToCppTranslation" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' AND $(TargetFramework) == 'netcoreapp3.0'">
+    <Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.0\CSharpToCppTranslator.exe $(ProjectDir) $(SolutionDir)cpp\$(ProjectName)\ .cs .cpp"></Exec>
+  </Target>
+
+</Project>

--- a/examples/experiments/test_new_script.sh
+++ b/examples/experiments/test_new_script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Test the new (fixed) version of the script
+
+cp test.csproj test_new_result.csproj
+echo "=== Testing new script behavior ==="
+echo "Before:"
+cat test_new_result.csproj
+
+# Apply the new fixed sed commands
+sed -i -e 's/<TargetFramework>netcoreapp3\.0<\/TargetFramework>/<TargetFramework>netcoreapp3.1<\/TargetFramework>/g' -e 's/netcoreapp3\.0<\/TargetFrameworks/netcoreapp3.1<\/TargetFrameworks/g' test_new_result.csproj
+
+echo ""
+echo "After (shows the fix - only TargetFramework tags changed, CSharpToCppTranslator path unchanged):"
+cat test_new_result.csproj

--- a/examples/experiments/test_old_result.csproj
+++ b/examples/experiments/test_old_result.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <Target Name="CSharpToCppTranslation" AfterTargets="PostBuildEvent" Condition="'$(OS)' == 'Windows_NT' AND $(TargetFramework) == 'netcoreapp3.1'">
+    <Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.1\CSharpToCppTranslator.exe $(ProjectDir) $(SolutionDir)cpp\$(ProjectName)\ .cs .cpp"></Exec>
+  </Target>
+
+</Project>

--- a/examples/experiments/test_old_script.sh
+++ b/examples/experiments/test_old_script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Test the old (problematic) version of the script
+
+cp test.csproj test_old_result.csproj
+echo "=== Testing old script behavior ==="
+echo "Before (problematic version):"
+cat test_old_result.csproj
+
+# Apply the old problematic sed command
+sed -i -e 's/netcoreapp3\.0/netcoreapp3.1/g' test_old_result.csproj
+
+echo ""
+echo "After (shows the problem - CSharpToCppTranslator path gets changed):"
+cat test_old_result.csproj


### PR DESCRIPTION
## Summary
- Fixed the AddNet5Support script to prevent it from updating C# to C++ translator paths
- The script was using overly broad regex patterns that replaced ALL occurrences of `netcoreapp3.0`, including CSharpToCppTranslator executable paths
- Made regex patterns more specific to only target `<TargetFramework>` and `<TargetFrameworks>` XML elements

## Problem
The original script used this pattern:
```bash
's/netcoreapp3\.0/netcoreapp3.1/g'
```

This would incorrectly change:
```xml
<Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.0\CSharpToCppTranslator.exe" />
```

To:
```xml
<Exec Command="..\..\CSharpToCppTranslator\bin\$(Configuration)\netcoreapp3.1\CSharpToCppTranslator.exe" />
```

## Solution
Now uses specific patterns:
```bash
's/<TargetFramework>netcoreapp3\.0<\/TargetFramework>/<TargetFramework>netcoreapp3.1<\/TargetFramework>/g'
's/netcoreapp3\.0\([;<]\)/netcoreapp3.1\1/g' 
's/netcoreapp3\.0<\/TargetFrameworks/netcoreapp3.1<\/TargetFrameworks/g'
```

This preserves CSharpToCppTranslator paths while properly updating project target frameworks.

## Test plan
- [x] Tested with sample .csproj file containing CSharpToCppTranslator references
- [x] Verified that only TargetFramework elements are updated
- [x] Confirmed that CSharpToCppTranslator paths remain unchanged
- [x] Verified script handles multiple target frameworks with semicolon separators

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #5