### PR TITLE
Move yml configuration files to Settings repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Scripts/issues/2
+Your prepared branch: issue-2-b35f2f2c
+Your prepared working directory: /tmp/gh-issue-solver-1757778863807
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Scripts/issues/2
-Your prepared branch: issue-2-b35f2f2c
-Your prepared working directory: /tmp/gh-issue-solver-1757778863807
-
-Proceed.

--- a/MultiProjectRepository/csharpCdWorkflow.yml
+++ b/MultiProjectRepository/csharpCdWorkflow.yml
@@ -10,6 +10,7 @@ env:
   NUGETTOKEN: ${{ secrets.NUGET_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SCRIPTS_BASE_URL: https://raw.githubusercontent.com/linksplatform/Scripts/main/MultiProjectRepository
+  SETTINGS_BASE_URL: https://raw.githubusercontent.com/linksplatform/Settings/main
   
 defaults:
   run:
@@ -129,7 +130,7 @@ jobs:
       run: |
         export REPOSITORY_NAME=$(basename ${{ github.repository }})
         wget "$SCRIPTS_BASE_URL/docfx.json"
-        wget "$SCRIPTS_BASE_URL/filter.yml"
-        wget "$SCRIPTS_BASE_URL/toc.yml"
+        wget "$SETTINGS_BASE_URL/filter.yml"
+        wget "$SETTINGS_BASE_URL/toc.yml"
         wget "$SCRIPTS_BASE_URL/publish-csharp-docs.sh"
         bash ./publish-csharp-docs.sh

--- a/MultiProjectRepository/filter.yml
+++ b/MultiProjectRepository/filter.yml
@@ -1,5 +1,0 @@
-apiRules:
-- exclude:
-    uidRegex: (Tests|Benchmarks)(\.[A-Za-z]+)?$
-- exclude:
-    uidRegex: CSharpToCppTranslator$

--- a/MultiProjectRepository/toc.yml
+++ b/MultiProjectRepository/toc.yml
@@ -1,5 +1,0 @@
-- name: Home
-  href: README.md
-- name: API Documentation
-  href: obj/api/
-  homepage: api/Platform.$REPOSITORY_NAME.html

--- a/SingleProjectRepository/publish-docs.sh
+++ b/SingleProjectRepository/publish-docs.sh
@@ -9,6 +9,10 @@ SHA=$(git rev-parse --verify HEAD)
 COMMIT_USER_NAME="linksplatform"
 COMMIT_USER_EMAIL="linksplatformtechnologies@gmail.com"
 REPOSITORY="github.com/linksplatform/$REPOSITORY_NAME"
+SETTINGS_BASE_URL="https://raw.githubusercontent.com/linksplatform/Settings/main"
+
+# Download configuration files from Settings repository
+wget "$SETTINGS_BASE_URL/toc.yml"
 
 # Insert repository name into DocFX's configuration files
 sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" toc.yml

--- a/SingleProjectRepository/toc.yml
+++ b/SingleProjectRepository/toc.yml
@@ -1,5 +1,0 @@
-- name: Home
-  href: README.md
-- name: API Documentation
-  href: obj/api/
-  homepage: api/Platform.$REPOSITORY_NAME.html


### PR DESCRIPTION
## 🎯 Summary

This PR implements the solution for issue #2 by moving yml configuration files from the Scripts repository to the Settings repository and updating all references to use the new location.

## 📋 Changes Made

### Files Moved to Settings Repository
- `filter.yml` - API filtering rules for DocFX documentation generation
- `toc.yml` - Table of contents configuration for documentation sites

### Scripts Repository Updates
- **MultiProjectRepository/csharpCdWorkflow.yml**: 
  - Added `SETTINGS_BASE_URL` environment variable
  - Updated wget commands to download `filter.yml` and `toc.yml` from Settings repository
- **SingleProjectRepository/publish-docs.sh**:
  - Added Settings repository URL configuration
  - Added wget command to download `toc.yml` before processing

### Files Removed
- `MultiProjectRepository/filter.yml`
- `MultiProjectRepository/toc.yml` 
- `SingleProjectRepository/toc.yml`

## 🔧 Implementation Details

The solution maintains backward compatibility by:
1. Keeping `docfx.json` files unchanged - they still reference yml files locally
2. Having workflows download the yml files from Settings repository before running documentation scripts
3. Using the existing `$REPOSITORY_NAME` variable substitution in yml files

## 📁 Settings Repository Files

The following files need to be added to the root of the Settings repository:

**filter.yml**:
```yaml
apiRules:
- exclude:
    uidRegex: (Tests|Benchmarks)(\.[A-Za-z]+)?$
- exclude:
    uidRegex: CSharpToCppTranslator$
```

**toc.yml**:
```yaml
- name: Home
  href: README.md
- name: API Documentation
  href: obj/api/
  homepage: api/Platform.$REPOSITORY_NAME.html
```

## ✅ Testing Required

After merging and adding files to Settings repository:
- [ ] Test C# project documentation generation
- [ ] Verify DocFX processing works correctly
- [ ] Confirm GitHub Actions workflows complete successfully

## 🔗 Fixes

Fixes #2

---
🤖 Generated with [Claude Code](https://claude.ai/code)