### PR TITLE
Combine multi-project and single-project scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Scripts/issues/1
-Your prepared branch: issue-1-531e8cce
-Your prepared working directory: /tmp/gh-issue-solver-1757829642000
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Scripts/issues/1
+Your prepared branch: issue-1-531e8cce
+Your prepared working directory: /tmp/gh-issue-solver-1757829642000
+
+Proceed.

--- a/Combined/README.md
+++ b/Combined/README.md
@@ -1,0 +1,68 @@
+# Combined Scripts
+
+This directory contains unified scripts that can work with both single-project and multi-project repository structures.
+
+## How It Works
+
+The scripts automatically detect the project structure:
+
+- **Multi-project**: Looks for `CSHARP_PACKAGE_VERSION.txt` files or `csharp/Platform.$REPOSITORY_NAME/` directory structure
+- **Single-project**: Looks for `Platform.$REPOSITORY_NAME.csproj` in the root directory
+
+## Available Scripts
+
+### C# Scripts
+
+1. **publish-csharp-release.sh**
+   - Creates GitHub releases for C# packages
+   - Multi-project: Uses version from `CSHARP_PACKAGE_VERSION.txt`
+   - Single-project: Extracts version from `.csproj` file
+
+2. **push-csharp-nuget.sh**
+   - Publishes NuGet packages
+   - Multi-project: Uses version from `CSHARP_PACKAGE_VERSION.txt`
+   - Single-project: Extracts version from generated package
+
+3. **format-csharp-document.sh**
+   - Formats C# code for LaTeX documentation
+   - Multi-project: Processes `./csharp/Platform.$REPOSITORY_NAME/` structure
+   - Single-project: Processes current directory
+
+4. **generate-csharp-pdf.sh**
+   - Generates PDF documentation from C# code
+   - Works with output from `format-csharp-document.sh`
+
+5. **publish-csharp-docs.sh**
+   - Publishes documentation to GitHub Pages
+   - Multi-project: Creates `csharp/` subdirectory structure
+   - Single-project: Uses root directory
+
+## Usage
+
+Simply use these scripts as drop-in replacements for the separate single/multi-project scripts. They will automatically adapt to your repository structure.
+
+### Requirements
+
+- `$REPOSITORY_NAME` environment variable must be set
+- For GitHub operations: `$GITHUB_TOKEN` environment variable
+- For NuGet operations: `$NUGETTOKEN` environment variable
+
+### Example
+
+```bash
+export REPOSITORY_NAME="MyLibrary"
+export GITHUB_TOKEN="your_token_here"
+export NUGETTOKEN="your_nuget_token_here"
+
+# These will work for both single and multi-project repositories
+./publish-csharp-release.sh
+./push-csharp-nuget.sh
+```
+
+## Migration
+
+To migrate from separate scripts:
+
+1. Replace calls to `MultiProjectRepository/script.sh` or `SingleProjectRepository/script.sh`
+2. Use the equivalent `Combined/script.sh` instead
+3. No other changes needed - the scripts are compatible with existing workflows

--- a/Combined/docfx.json
+++ b/Combined/docfx.json
@@ -1,0 +1,39 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/*.sln" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "src": ""
+        }
+      ],
+      "dest": "obj/api",
+      "filter": "filter.yml",
+      "properties": { "TargetFramework": "netstandard2.0" }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "src": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "*.md", "toc.yml" ]
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "LinksPlatform's Platform.$REPOSITORY_NAME Library",
+      "_enableSearch": true,
+      "_gitContribute": {
+        "branch": "master"
+      },
+      "_gitUrlPattern": "github"
+    },
+    "markdownEngineName": "markdig",
+    "dest": "_site",
+    "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ]
+  }
+}

--- a/Combined/format-csharp-document.sh
+++ b/Combined/format-csharp-document.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# Function to detect project structure
+detect_project_structure() {
+    if [ -d "csharp" ] && [ -d "csharp/Platform.$REPOSITORY_NAME" ]; then
+        echo "multi"
+    elif [ -f "Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "single"
+    else
+        echo "unknown"
+    fi
+}
+
+# Function to clean up auto-generated files for multi-project
+cleanup_multi_project() {
+    set +e
+    find "./csharp/Platform.$REPOSITORY_NAME/obj" -type f -iname "*.cs" -delete 2>/dev/null
+    find "./csharp/Platform.$REPOSITORY_NAME.Tests/obj" -type f -iname "*.cs" -delete 2>/dev/null
+    set -e
+}
+
+# Function to clean up auto-generated files for single-project
+cleanup_single_project() {
+    find ./obj -type f -iname "*.cs" -delete 2>/dev/null || true
+}
+
+# Function to process files for multi-project
+process_multi_project_files() {
+    # Project files
+    find "./csharp/Platform.$REPOSITORY_NAME" -type f -iname '*.cs' | sort -b | python format-csharp-files.py
+    
+    # Tests files (if they exist)
+    if [ -d "./csharp/Platform.$REPOSITORY_NAME.Tests" ]; then
+        find "./csharp/Platform.$REPOSITORY_NAME.Tests" -type f -iname '*.cs' | sort -b | python format-csharp-files.py
+    fi
+}
+
+# Function to process files for single-project
+process_single_project_files() {
+    # Project files
+    find . -type f -iname '*.cs' | sort -b | python format-csharp-files.py
+}
+
+# Function to output LaTeX header
+output_latex_header() {
+    printf """
+\\documentclass[11pt,a4paper,fleqn]{report}
+\\usepackage[left=5mm,top=5mm,right=5mm,bottom=5mm]{geometry}
+\\textwidth=200mm
+\\usepackage[utf8]{inputenc}
+\\usepackage[T1]{fontenc}
+\\usepackage[T2A]{fontenc}
+\\usepackage{fvextra}
+\\usepackage{minted}
+\\usemintedstyle{vs}
+\\usepackage{makeidx}
+\\usepackage[columns=1]{idxlayout}
+\\makeindex
+\\renewcommand{\\thesection}{\\arabic{chapter}.\\arabic{section}}
+\\setcounter{chapter}{1}
+\\setcounter{section}{0}
+\\usepackage[tiny]{titlesec}
+\\titlespacing\\chapter{0mm}{0mm}{0mm}
+\\titlespacing\\section{0mm}{0mm}{0mm}
+\\DeclareUnicodeCharacter{221E}{\\ensuremath{\\infty}}
+\\DeclareUnicodeCharacter{FFFD}{\\ensuremath{ }}
+\\usepackage{fancyhdr}
+\\pagestyle{fancy}
+\\fancyhf{}
+\\fancyfoot[C]{\\thepage}
+\\renewcommand{\\headrulewidth}{0mm}
+\\renewcommand{\\footrulewidth}{0mm}
+\\renewcommand{\\baselinestretch}{0.7}
+\\begin{document}
+\\sf
+\\noindent{\\Large LinksPlatform's Platform.${REPOSITORY_NAME} Class Library}
+"""
+}
+
+# Function to output LaTeX footer
+output_latex_footer() {
+    printf """
+\\printindex
+\\end{document}
+"""
+}
+
+# Ensure format-csharp-files.py exists
+ensure_format_script() {
+    local script_path=""
+    if [ "$PROJECT_TYPE" = "multi" ] && [ -f "format-csharp-files.py" ]; then
+        script_path="format-csharp-files.py"
+    elif [ "$PROJECT_TYPE" = "single" ] && [ -f "format-csharp-files.py" ]; then
+        script_path="format-csharp-files.py"
+    elif [ -f "../Utils/format-csharp-files.py" ]; then
+        cp "../Utils/format-csharp-files.py" .
+        script_path="format-csharp-files.py"
+    elif [ -f "MultiProjectRepository/format-csharp-files.py" ]; then
+        cp "MultiProjectRepository/format-csharp-files.py" .
+        script_path="format-csharp-files.py"
+    elif [ -f "SingleProjectRepository/format-csharp-files.py" ]; then
+        cp "SingleProjectRepository/format-csharp-files.py" .
+        script_path="format-csharp-files.py"
+    else
+        echo "format-csharp-files.py not found. Please ensure it's available."
+        exit 1
+    fi
+}
+
+# Main execution
+PROJECT_TYPE=$(detect_project_structure)
+
+echo "Detected project structure: $PROJECT_TYPE"
+
+case $PROJECT_TYPE in
+    "multi")
+        cleanup_multi_project
+        ;;
+    "single")
+        cleanup_single_project
+        ;;
+    "unknown")
+        echo "Could not detect project structure. Expected either:"
+        echo "  Multi-project: ./csharp/Platform.\$REPOSITORY_NAME/ directory"
+        echo "  Single-project: Platform.\$REPOSITORY_NAME.csproj file"
+        exit 1
+        ;;
+esac
+
+# Download fvextra package
+wget https://raw.githubusercontent.com/gpoore/fvextra/cc1c0c5f7b92023cfec67084e2a87bdac520414c/fvextra/fvextra.sty
+
+# Ensure format script is available
+ensure_format_script
+
+# Output LaTeX header
+output_latex_header
+
+# Process files based on project type
+case $PROJECT_TYPE in
+    "multi")
+        process_multi_project_files
+        ;;
+    "single")
+        process_single_project_files
+        ;;
+esac
+
+# Output LaTeX footer
+output_latex_footer

--- a/Combined/format-csharp-files.py
+++ b/Combined/format-csharp-files.py
@@ -1,0 +1,19 @@
+﻿#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+for line in sys.stdin.readlines():
+    line = line.strip()
+    print("\\index{%s}" % (line.replace('_','\\_')))
+    print("\\begin{section}{%s}" % (line.replace('_','\\_')))
+    #print "\\inputminted[tabsize=2,breaklines,linenos=true]{csharp}{%s}" % (line)
+    print("\\begin{minted}[tabsize=2,breaklines,breakanywhere,linenos=true,xleftmargin=7mm,framesep=4mm]{csharp}")
+    f = open(line,"rt")
+    c = "\n".join([x.strip("\n") for x in f.readlines()])
+    f.close()
+    c = c.replace(u'\ufeff','')
+    print(c)
+    print("\\end{minted}")
+    print("\\end{section}")
+    print("\n")

--- a/Combined/generate-csharp-pdf.sh
+++ b/Combined/generate-csharp-pdf.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+sudo apt-get update
+sudo apt-get install -y texlive texlive-lang-cyrillic texlive-latex-extra python-pygments ghostscript
+
+# Generate tex file using the combined format script
+bash format-csharp-document.sh > document.tex
+
+# Generate pdf
+latex -shell-escape document.tex
+makeindex document
+latex -shell-escape document.tex
+dvipdf document.dvi document.pdf
+dvips document.dvi
+
+# Copy pdf to publish location (will be used in the next script)
+mkdir -p _site
+cp document.pdf "_site/Platform.$REPOSITORY_NAME.pdf"
+
+# Clean up
+rm document.tex
+rm document.dvi
+rm document.pdf

--- a/Combined/publish-csharp-docs.sh
+++ b/Combined/publish-csharp-docs.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+sudo apt-get install nuget
+
+# Function to detect project structure
+detect_project_structure() {
+    if [ -d "csharp" ] && [ -d "csharp/Platform.$REPOSITORY_NAME" ]; then
+        echo "multi"
+    elif [ -f "Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "single"
+    else
+        echo "unknown"
+    fi
+}
+
+# Settings
+TARGET_BRANCH="gh-pages"
+SHA=$(git rev-parse --verify HEAD)
+COMMIT_USER_NAME="linksplatform"
+COMMIT_USER_EMAIL="linksplatformtechnologies@gmail.com"
+REPOSITORY="github.com/linksplatform/$REPOSITORY_NAME"
+
+# Insert repository name into DocFX's configuration files
+sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" toc.yml
+sed -i "s/\$REPOSITORY_NAME/$REPOSITORY_NAME/g" docfx.json
+
+# DocFX installation
+PROJECT_TYPE=$(detect_project_structure)
+
+if [ "$PROJECT_TYPE" = "multi" ]; then
+    nuget install docfx.console -Version 2.51
+else
+    nuget install docfx.console
+fi
+
+mono $(echo ./*docfx.console.*)/tools/docfx.exe docfx.json
+
+# Clone the existing gh-pages for this repo into out/
+# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy)
+git clone "https://$REPOSITORY" out
+cd out || exit
+git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
+cd ..
+
+# Handle different project structures
+if [ "$PROJECT_TYPE" = "multi" ]; then
+    mkdir -p out/csharp
+    # Clean out existing contents
+    rm -rf out/csharp/**/* || exit 0
+    # Copy generated docs site
+    cp -r _site/* out/csharp/
+    cd out/csharp || exit
+else
+    # Clean out existing contents
+    rm -rf out/**/* || exit 0
+    # Copy generated docs site
+    cp -r _site/* out
+    cd out || exit
+fi
+
+# Do not use index.md
+cp README.html index.html
+
+# Enter repository's folder (for multi-project, we're already in csharp subfolder)
+if [ "$PROJECT_TYPE" = "multi" ]; then
+    cd ..
+fi
+
+# Now let's go have some fun with the cloned repo
+git config user.name "$COMMIT_USER_NAME"
+git config user.email "$COMMIT_USER_EMAIL"
+git remote rm origin
+git remote add origin "https://linksplatform:$GITHUB_TOKEN@$REPOSITORY.git"
+
+# Commit the "changes", i.e. the new version.
+# The delta will show diffs between new and old versions.
+git add --all
+git commit -m "Deploy to GitHub Pages: $SHA"
+
+# Now that we're all set up, we can push.
+git push "https://linksplatform:$GITHUB_TOKEN@$REPOSITORY.git" "$TARGET_BRANCH"
+cd ..
+
+# Clean up
+rm -rf out
+rm -rf _site
+rm -rf docfx.console*

--- a/Combined/publish-csharp-release.sh
+++ b/Combined/publish-csharp-release.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# Function to detect project structure
+detect_project_structure() {
+    if [ -f "CSHARP_PACKAGE_VERSION.txt" ] && [ -f "CSHARP_PACKAGE_RELEASE_NOTES.txt" ]; then
+        echo "multi"
+    elif [ -f "Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "single"
+    elif [ -d "csharp" ] && [ -f "csharp/Platform.$REPOSITORY_NAME/Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "multi"
+    else
+        echo "unknown"
+    fi
+}
+
+# Function to get package info for multi-project structure
+get_multi_project_info() {
+    if [ -f "CSHARP_PACKAGE_VERSION.txt" ]; then
+        PACKAGE_VERSION=$(<CSHARP_PACKAGE_VERSION.txt)
+    else
+        echo "CSHARP_PACKAGE_VERSION.txt not found in multi-project repository."
+        exit 1
+    fi
+    
+    if [ -f "CSHARP_PACKAGE_RELEASE_NOTES.txt" ]; then
+        PACKAGE_RELEASE_NOTES=$(<CSHARP_PACKAGE_RELEASE_NOTES.txt)
+    else
+        PACKAGE_RELEASE_NOTES="Release $PACKAGE_VERSION"
+    fi
+    
+    PACKAGE_URL="https://www.nuget.org/packages/Platform.$REPOSITORY_NAME/$PACKAGE_VERSION"
+    TAG="csharp_$PACKAGE_VERSION"
+    RELEASE_NAME="[C#] $PACKAGE_VERSION"
+}
+
+# Function to get package info for single-project structure  
+get_single_project_info() {
+    sudo apt-get install -y xmlstarlet
+    
+    PACKAGE_VERSION=$(xmlstarlet sel -t -m '//VersionPrefix[1]' -v . -n <"Platform.$REPOSITORY_NAME.csproj")
+    PACKAGE_RELEASE_NOTES=$(xmlstarlet sel -t -m '//PackageReleaseNotes[1]' -v . -n <"Platform.$REPOSITORY_NAME.csproj")
+    
+    if [ -z "$PACKAGE_VERSION" ]; then
+        echo "Could not extract VersionPrefix from Platform.$REPOSITORY_NAME.csproj"
+        exit 1
+    fi
+    
+    PACKAGE_URL="https://www.nuget.org/packages/Platform.$REPOSITORY_NAME/$PACKAGE_VERSION"
+    TAG="$PACKAGE_VERSION"
+    RELEASE_NAME="$PACKAGE_VERSION"
+}
+
+# Function to check if release already exists
+check_existing_release() {
+    local tag=$1
+    TAG_ID=$(curl --request GET --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --header "authorization: Bearer ${GITHUB_TOKEN}" | jq -r '.id')
+    
+    if [ "$TAG_ID" != "null" ]; then
+        echo "Release with tag $tag already published."
+        exit 0
+    fi
+}
+
+# Function to create release
+create_release() {
+    local tag=$1
+    local name=$2
+    local body=$3
+    
+    echo "Repository name: $GITHUB_REPOSITORY";
+    echo "Tag: $tag";
+    echo "Default branch: $DEFAULT_BRANCH";
+    echo "Release name: $name";
+    echo "Release body: $body";
+    
+    gh release create "${tag}" -t "${name}" -n "${body}"
+}
+
+# Main execution
+PROJECT_TYPE=$(detect_project_structure)
+
+echo "Detected project structure: $PROJECT_TYPE"
+
+case $PROJECT_TYPE in
+    "multi")
+        get_multi_project_info
+        ;;
+    "single")
+        get_single_project_info
+        ;;
+    "unknown")
+        echo "Could not detect project structure. Expected either:"
+        echo "  Multi-project: CSHARP_PACKAGE_VERSION.txt and CSHARP_PACKAGE_RELEASE_NOTES.txt"
+        echo "  Single-project: Platform.\$REPOSITORY_NAME.csproj"
+        exit 1
+        ;;
+esac
+
+# Create release body with separator
+SEPARATOR="
+
+"
+RELEASE_BODY="$PACKAGE_URL$SEPARATOR$PACKAGE_RELEASE_NOTES"
+
+# Check if release already exists
+check_existing_release "$TAG"
+
+# Create the release
+create_release "$TAG" "$RELEASE_NAME" "$RELEASE_BODY"

--- a/Combined/push-csharp-nuget.sh
+++ b/Combined/push-csharp-nuget.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+# Function to detect project structure
+detect_project_structure() {
+    if [ -f "CSHARP_PACKAGE_VERSION.txt" ]; then
+        echo "multi"
+    elif [ -f "Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "single"
+    elif [ -d "csharp" ] && [ -f "csharp/Platform.$REPOSITORY_NAME/Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "multi"
+    else
+        echo "unknown"
+    fi
+}
+
+# Function to get version for multi-project structure
+get_multi_project_version() {
+    PACKAGE_VERSION=$(<CSHARP_PACKAGE_VERSION.txt)
+    echo "Using version from CSHARP_PACKAGE_VERSION.txt: $PACKAGE_VERSION"
+}
+
+# Function to get version for single-project structure
+get_single_project_version() {
+    # Pack first to generate the package file
+    dotnet pack -c Release
+    
+    # Extract version from generated package file
+    PackageFileNamePrefix="bin/Release/Platform.$REPOSITORY_NAME."
+    PackageFileNameSuffix=".nupkg"
+    PackageFileName=$(echo "$PackageFileNamePrefix"*"$PackageFileNameSuffix")
+    PACKAGE_VERSION="${PackageFileName#$PackageFileNamePrefix}"
+    PACKAGE_VERSION="${PackageFileNameSuffix%$PackageFileNameSuffix}"
+    echo "Extracted version from package file: $PACKAGE_VERSION"
+}
+
+# Function to check if NuGet package already exists
+check_nuget_exists() {
+    local version=$1
+    NuGetPackageUrl="https://globalcdn.nuget.org/packages/Platform.$REPOSITORY_NAME.$version.nupkg"
+    NuGetPackageUrl=$(echo "$NuGetPackageUrl" | tr '[:upper:]' '[:lower:]')
+    
+    NuGetPageStatus="$(curl -Is "$NuGetPackageUrl" | head -1)"
+    StatusContents=( $NuGetPageStatus )
+    if [ "${StatusContents[1]}" == "200" ]; then
+        echo "NuGet with current version is already pushed."
+        exit 0
+    fi
+    
+    echo "The NuGet package does not exist at $NuGetPackageUrl"
+}
+
+# Function to pack and push NuGet package
+pack_and_push() {
+    # Pack NuGet package (if not already packed for single-project)
+    if [ "$PROJECT_TYPE" = "multi" ]; then
+        dotnet pack -c Release
+    fi
+    
+    # Push NuGet package
+    if [ "$PROJECT_TYPE" = "single" ]; then
+        dotnet nuget push ./**/*.nupkg -s https://api.nuget.org/v3/index.json -k "${NUGETTOKEN}"
+    else
+        dotnet nuget push ./**/*.nupkg -s https://api.nuget.org/v3/index.json --skip-duplicate -k "${NUGETTOKEN}"
+    fi
+}
+
+# Function to cleanup
+cleanup() {
+    find . -type f -name '*.nupkg' -delete
+    find . -type f -name '*.snupkg' -delete
+}
+
+# Main execution
+PROJECT_TYPE=$(detect_project_structure)
+
+echo "Detected project structure: $PROJECT_TYPE"
+
+case $PROJECT_TYPE in
+    "multi")
+        get_multi_project_version
+        ;;
+    "single")
+        get_single_project_version
+        ;;
+    "unknown")
+        echo "Could not detect project structure. Expected either:"
+        echo "  Multi-project: CSHARP_PACKAGE_VERSION.txt"
+        echo "  Single-project: Platform.\$REPOSITORY_NAME.csproj"
+        exit 1
+        ;;
+esac
+
+# Check if package already exists
+check_nuget_exists "$PACKAGE_VERSION"
+
+# Pack and push
+pack_and_push
+
+# Clean up
+cleanup

--- a/Combined/toc.yml
+++ b/Combined/toc.yml
@@ -1,0 +1,5 @@
+- name: Home
+  href: README.md
+- name: API Documentation
+  href: obj/api/
+  homepage: api/Platform.$REPOSITORY_NAME.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Scripts
 Automation scripts for Continuous Integration, Continuous Deploy and Code Changes
+
+## Directory Structure
+
+- **MultiProjectRepository/**: Scripts designed for multi-project repository structures
+- **SingleProjectRepository/**: Scripts designed for single-project repository structures  
+- **Combined/**: Unified scripts that automatically adapt to both single and multi-project structures
+- **Utils/**: Utility scripts and shared components
+- **CodeChanges/**: Scripts for automated code modifications
+
+## Recommended Usage
+
+For new projects, use the **Combined/** scripts as they automatically detect your repository structure and adapt accordingly. This eliminates the need to choose between single-project and multi-project variants.

--- a/experiments/test_detection.sh
+++ b/experiments/test_detection.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Function to detect project structure (extracted from our combined script)
+detect_project_structure() {
+    if [ -f "CSHARP_PACKAGE_VERSION.txt" ] && [ -f "CSHARP_PACKAGE_RELEASE_NOTES.txt" ]; then
+        echo "multi"
+    elif [ -f "Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "single"
+    elif [ -d "csharp" ] && [ -f "csharp/Platform.$REPOSITORY_NAME/Platform.$REPOSITORY_NAME.csproj" ]; then
+        echo "multi"
+    else
+        echo "unknown"
+    fi
+}
+
+# Set test repository name
+export REPOSITORY_NAME="TestRepo"
+
+# Test 1: Multi-project with version files
+echo "=== Test 1: Multi-project with version files ==="
+mkdir -p test1
+cd test1
+echo "1.0.0" > CSHARP_PACKAGE_VERSION.txt
+echo "Test release" > CSHARP_PACKAGE_RELEASE_NOTES.txt
+result=$(detect_project_structure)
+echo "Result: $result (expected: multi)"
+cd ..
+
+# Test 2: Single-project
+echo "=== Test 2: Single-project ==="
+mkdir -p test2  
+cd test2
+touch Platform.TestRepo.csproj
+result=$(detect_project_structure)
+echo "Result: $result (expected: single)"
+cd ..
+
+# Test 3: Multi-project with csharp directory
+echo "=== Test 3: Multi-project with csharp directory ==="
+mkdir -p test3/csharp/Platform.TestRepo
+cd test3
+touch csharp/Platform.TestRepo/Platform.TestRepo.csproj
+result=$(detect_project_structure)
+echo "Result: $result (expected: multi)"
+cd ..
+
+# Test 4: Unknown structure
+echo "=== Test 4: Unknown structure ==="
+mkdir -p test4
+cd test4
+result=$(detect_project_structure)
+echo "Result: $result (expected: unknown)"
+cd ..
+
+# Clean up
+rm -rf test1 test2 test3 test4
+
+echo "=== All tests completed ==="

--- a/experiments/test_structure_detection.sh
+++ b/experiments/test_structure_detection.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Create test directory structure
+mkdir -p experiments/test_multi/csharp/Platform.TestRepo
+mkdir -p experiments/test_single
+
+# Test multi-project detection
+cd experiments/test_multi
+echo "1.0.0" > CSHARP_PACKAGE_VERSION.txt
+echo "Test release notes" > CSHARP_PACKAGE_RELEASE_NOTES.txt
+mkdir -p csharp/Platform.TestRepo
+touch csharp/Platform.TestRepo/Platform.TestRepo.csproj
+
+# Extract detection function and test it
+source ../../Combined/publish-csharp-release.sh
+detect_result=$(detect_project_structure)
+echo "Multi-project detection result: $detect_result"
+
+cd ../test_single
+touch Platform.TestRepo.csproj
+
+# Test single-project detection
+detect_result=$(detect_project_structure)
+echo "Single-project detection result: $detect_result"
+
+cd ../..
+
+# Clean up
+rm -rf experiments/test_multi experiments/test_single


### PR DESCRIPTION
## Summary
- Created unified `Combined/` directory with scripts that automatically detect project structure
- Scripts adapt between single-project and multi-project repositories without manual configuration  
- Eliminates the need to choose between separate script variants

## Changes Made
- **Combined/publish-csharp-release.sh**: Unified release creation with auto-detection
- **Combined/push-csharp-nuget.sh**: Unified NuGet publishing with version extraction
- **Combined/format-csharp-document.sh**: Unified documentation formatting
- **Combined/publish-csharp-docs.sh**: Unified GitHub Pages documentation publishing
- **Combined/generate-csharp-pdf.sh**: Unified PDF generation
- **experiments/**: Test scripts validating structure detection logic
- **README.md**: Updated documentation explaining new Combined/ directory

## Test Plan
- [x] Created comprehensive test scripts in `experiments/` directory
- [x] Verified bash script syntax validation
- [x] Tested project structure detection logic for all scenarios:
  - Multi-project with version files
  - Multi-project with csharp/ directory structure  
  - Single-project with .csproj files
  - Unknown/invalid structures
- [x] All detection tests pass successfully

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #1