### PR TITLE
Add script to replace .AwaitResult() with .Result in C# files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-20-d6fbf569
-Your prepared working directory: /tmp/gh-issue-solver-1761797971549
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-20-d6fbf569
+Your prepared working directory: /tmp/gh-issue-solver-1761797971549
+
+Proceed.

--- a/CodeChanges/ReplaceAwaitResultWithResult.sh
+++ b/CodeChanges/ReplaceAwaitResultWithResult.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Replace .AwaitResult() with .Result in all .cs files
+# This handles cases with or without spaces around the dot operator
+find . -type f -name "*.cs" -exec sed -i 's/\.\s*AwaitResult\s*()/.Result/g' {} \;


### PR DESCRIPTION
## Summary

This PR adds a new script `ReplaceAwaitResultWithResult.sh` that automates the replacement of `.AwaitResult()` calls with `.Result` property access in all C# files.

### Changes
- Created `CodeChanges/ReplaceAwaitResultWithResult.sh`
- The script uses `sed` with regex to find and replace `.AwaitResult()` with `.Result`
- Handles edge cases with spaces around the dot operator (e.g., `. AwaitResult ()`)

### Usage
```bash
bash CodeChanges/ReplaceAwaitResultWithResult.sh
```

The script will recursively find all `.cs` files in the current directory and subdirectories and perform the replacement.

### Testing
- Tested locally with various edge cases including:
  - Simple `.AwaitResult()` calls
  - Chained method calls
  - Multiple occurrences on the same line
  - Cases with extra spaces around operators
  - Correctly ignores `AwaitResult` without parentheses

Fixes #20

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)