### PR TITLE
Add scripts to update .NET projects to version 10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Scripts/issues/36
-Your prepared branch: issue-36-b9df450d9c4a
-Your prepared working directory: /tmp/gh-issue-solver-1766959239755
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Scripts/issues/36
+Your prepared branch: issue-36-b9df450d9c4a
+Your prepared working directory: /tmp/gh-issue-solver-1766959239755
+
+Proceed.

--- a/CodeChanges/UpdateDotNetVersion/UpdateNet9ToNet10.sh
+++ b/CodeChanges/UpdateDotNetVersion/UpdateNet9ToNet10.sh
@@ -1,0 +1,8 @@
+sed -i '' 's/net9/net10/g' ./**/*/.github/**/*.yml
+
+sed -i '' 's/net9/net10/g' ./**/*.csproj
+
+# Remove duplicate target frameworks (e.g., net10;net10 -> net10)
+sed -i '' 's|<TargetFrameworks>net10;net10</TargetFrameworks>|<TargetFramework>net10</TargetFramework>|g' ./**/*.csproj
+
+perl -0777 -pi -e 's|<PackageReleaseNotes>.*?</PackageReleaseNotes>|<PackageReleaseNotes>Update target framework from net9 to net10.</PackageReleaseNotes>|gs' ./**/*.csproj

--- a/CodeChanges/UpdateDotNetVersion/UpdateToNet10.sh
+++ b/CodeChanges/UpdateDotNetVersion/UpdateToNet10.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Update .NET 6 to .NET 10
+sed -i '' 's/net6\.0/net10.0/g' ./**/*.csproj
+sed -i '' 's/net6/net10/g' ./**/*/.github/**/*.yml
+
+# Update .NET 7 to .NET 10
+sed -i '' 's/net7\.0/net10.0/g' ./**/*.csproj
+sed -i '' 's/net7/net10/g' ./**/*.csproj
+sed -i '' 's/net7/net10/g' ./**/*/.github/**/*.yml
+
+# Update .NET 8 to .NET 10
+sed -i '' 's/net8\.0/net10.0/g' ./**/*.csproj
+sed -i '' 's/net8/net10/g' ./**/*.csproj
+sed -i '' 's/net8/net10/g' ./**/*/.github/**/*.yml
+
+# Update .NET 9 to .NET 10
+sed -i '' 's/net9\.0/net10.0/g' ./**/*.csproj
+sed -i '' 's/net9/net10/g' ./**/*.csproj
+sed -i '' 's/net9/net10/g' ./**/*/.github/**/*.yml
+
+# Handle other .NET versions to .NET 10
+sed -i '' 's/netcoreapp3\.1/net10.0/g' ./**/*.csproj
+sed -i '' 's/net5\.0/net10.0/g' ./**/*.csproj
+sed -i '' 's/netstandard2\.0/net10.0/g' ./**/*.csproj
+sed -i '' 's/netstandard2\.1/net10.0/g' ./**/*.csproj
+
+# Remove duplicate target frameworks (e.g., net10;net10 -> net10)
+sed -i '' 's|<TargetFrameworks>net10;net10</TargetFrameworks>|<TargetFramework>net10</TargetFramework>|g' ./**/*.csproj
+sed -i '' 's|<TargetFrameworks>net10\.0;net10\.0</TargetFrameworks>|<TargetFramework>net10.0</TargetFramework>|g' ./**/*.csproj
+
+# Update package release notes to reflect the upgrade
+perl -0777 -pi -e 's|<PackageReleaseNotes>.*?</PackageReleaseNotes>|<PackageReleaseNotes>Update target framework to net10.</PackageReleaseNotes>|gs' ./**/*.csproj
+
+echo "Updated all .NET projects to .NET 10"


### PR DESCRIPTION
## Summary
- Add `UpdateToNet10.sh` script to update all .NET projects from various versions (6, 7, 8, 9, netcoreapp3.1, net5.0, netstandard2.x) to .NET 10
- Add `UpdateNet9ToNet10.sh` script for incremental update from .NET 9 to .NET 10

The scripts follow the same pattern as the existing `UpdateToNet8.sh` and `UpdateNet7ToNet8.sh` scripts.

## Changes
- Updates `.csproj` files to use `net10.0` target framework
- Updates GitHub Actions workflow files (`.github/**/*.yml`) to use `net10`
- Removes duplicate target frameworks (e.g., `net10;net10` -> `net10`)
- Updates package release notes to reflect the upgrade

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)